### PR TITLE
Update .gitignore to exclude .target and demo/target directories; add…

### DIFF
--- a/demo/src/main/java/com/attendace/dao/handlers/Dao_course.java
+++ b/demo/src/main/java/com/attendace/dao/handlers/Dao_course.java
@@ -82,7 +82,7 @@ public class Dao_course extends Handler {
                 row.add(rs.getString("course_topic"));
                 row.add(rs.getString("course_desc"));
                 row.add(Boolean.toString(rs.getBoolean("attendance_avaible")));
-                row.add(Integer.toString(rs.getInt("attendance_key")));
+                row.add(rs.getString("attendance_key"));
                 row.add(Integer.toString(rs.getInt("min_attendance")));
                 row.add(Integer.toString(rs.getInt("max_attendance")));
                 row.add(Boolean.toString(rs.getBoolean("course_active")));

--- a/demo/src/test/java/com/attendace/dao/handlers/Dao_staffTest.java
+++ b/demo/src/test/java/com/attendace/dao/handlers/Dao_staffTest.java
@@ -65,7 +65,6 @@ public class Dao_staffTest {
 
         Request request = new Request(RequestDao.STAFF, RequestType.SETDATA, object);
         assertEquals(null, handler.handle(request));
-
     }
 
     @Test


### PR DESCRIPTION
This pull request includes a minor update to how data is retrieved and formatted in the `Dao_course` class, as well as a small cleanup in the `Dao_staffTest` test file. The most significant change is to the data type used for the `attendance_key` field.

**Data handling improvements:**

* Changed the retrieval of `attendance_key` in `Dao_course` from `Integer.toString(rs.getInt("attendance_key"))` to `rs.getString("attendance_key")`, ensuring the value is fetched as a string directly, which may help preserve formatting or handle nulls better.

**Test code cleanup:**

* Removed an unnecessary blank line at the end of the `testSetData()` method in `Dao_staffTest`, resulting in a slightly cleaner test file.… newline in LoginInterfaceController